### PR TITLE
Fix dropped payment notifications in BareBitcoinListener

### DIFF
--- a/plugin/Services/BareBitcoinListener.cs
+++ b/plugin/Services/BareBitcoinListener.cs
@@ -128,6 +128,11 @@ public class BareBitcoinListener : ILightningInvoiceListener
                 _logger.LogDebug("Polling cancelled");
                 break;
             }
+            catch (ChannelClosedException)
+            {
+                _logger.LogDebug("Invoice channel closed, stopping polling");
+                break;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error while polling for invoice updates");


### PR DESCRIPTION
## Summary
- Replace `TryWrite` with `WriteAsync` in `BareBitcoinListener` to prevent silently dropped payment notifications when the channel is full

Closes #1

## Test plan
- [ ] Verify payment notifications are no longer silently dropped under load
- [ ] Confirm `WriteAsync` awaits until the channel has capacity instead of failing silently