### PR TITLE
Fix issue #5: Remove HttpContext dependency and fix test deps

### DIFF
--- a/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
+++ b/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <RollForward>Major</RollForward>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -18,7 +19,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\plugin\BTCPayServer.Plugins.BareBitcoin.csproj" />
+        <ProjectReference Include="..\plugin\BTCPayServer.Plugins.BareBitcoin.csproj">
+            <Private>true</Private>
+            <ExcludeAssets>none</ExcludeAssets>
+        </ProjectReference>
+        <ProjectReference Include="..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj" />
     </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- Fixes test project so existing tests pass in CI: adds `RollForward=Major` for .NET 9 runtime compatibility and adds direct BTCPayServer project reference to resolve transitive assembly loading (`BTCPayServer.Lightning.Common`)
- The core fix (removing `IHttpContextAccessor` from the lightning client path) was already merged in eeb29e6

## Test plan
- [x] `dotnet build plugin/BTCPayServer.Plugins.BareBitcoin.csproj` succeeds
- [x] `dotnet test BTCPayServer.Plugins.Tests/` — all 2 tests pass
- [x] No remaining `IHttpContextAccessor`/`HttpContext` references in plugin/

Closes #5