### PR TITLE
Pin GitHub Actions workflows to immutable SHAs

### DIFF
--- a/.github/workflows/codex-pull-request-code-review.yml
+++ b/.github/workflows/codex-pull-request-code-review.yml
@@ -1,4 +1,9 @@
 name: Codex Pull Request Code Review
+# NOTE: Actions are pinned to commit SHAs for supply-chain security.
+# To update, resolve the new tag to a SHA:
+#   gh api repos/OWNER/REPO/git/ref/tags/TAG --jq '.object.sha'
+# If the result type is "tag" (annotated), dereference with:
+#   gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'
 
 on:
   pull_request:
@@ -18,7 +23,7 @@ jobs:
       final_message: ${{ steps.run_codex.outputs['final-message'] }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
@@ -40,7 +45,7 @@ jobs:
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: |
@@ -75,7 +80,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post Codex feedback
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -1,4 +1,9 @@
 name: Gemini Code Review
+# NOTE: Actions are pinned to commit SHAs for supply-chain security.
+# To update, resolve the new tag to a SHA:
+#   gh api repos/OWNER/REPO/git/ref/tags/TAG --jq '.object.sha'
+# If the result type is "tag" (annotated), dereference with:
+#   gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'
 
 on:
   pull_request:
@@ -19,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -55,7 +60,7 @@ jobs:
 
       - name: Run Gemini PR Review
         id: gemini
-        uses: google-github-actions/run-gemini-cli@v0
+        uses: google-github-actions/run-gemini-cli@9dbec29a20fab3f35017a40ad0eb798a257d4d51 # v0
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           prompt: |
@@ -79,7 +84,7 @@ jobs:
 
       - name: Post Gemini feedback
         if: always() && steps.gemini.outputs.summary != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |
@@ -124,7 +129,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -1,4 +1,9 @@
 name: Plugin Builder Compatibility
+# NOTE: Actions are pinned to commit SHAs for supply-chain security.
+# To update, resolve the new tag to a SHA:
+#   gh api repos/OWNER/REPO/git/ref/tags/TAG --jq '.object.sha'
+# If the result type is "tag" (annotated), dereference with:
+#   gh api repos/OWNER/REPO/git/tags/SHA --jq '.object.sha'
 
 on:
   pull_request:
@@ -15,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
## Summary
- Pin all third-party `uses:` references in workflow files to full commit SHAs, mitigating supply-chain risk from mutable tag retargeting
- Add maintenance comments explaining how to resolve new tags to SHAs using `gh api`

## Test plan
- [ ] Verify all three workflows trigger and pass on this PR

Closes #9