### PR TITLE
Poll tracked invoices concurrently

### DIFF
--- a/plugin/Services/BareBitcoinListener.cs
+++ b/plugin/Services/BareBitcoinListener.cs
@@ -107,7 +107,11 @@ public class BareBitcoinListener : ILightningInvoiceListener
                         var invoice = await _lightningClient.GetInvoice(invoiceId, token);
                         results.Add((invoiceId, invoice));
                     }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    catch (OperationCanceledException) when (_cts.Token.IsCancellationRequested)
+                    {
+                        throw; // Shutdown requested, propagate to stop the loop
+                    }
+                    catch (Exception ex)
                     {
                         _logger.LogWarning(ex, "Failed to poll invoice {InvoiceId}, will retry next cycle", invoiceId);
                     }


### PR DESCRIPTION
## Summary
- Replace sequential `foreach` polling loop with concurrent `Task.WhenAll` execution, bounded by a `SemaphoreSlim(10)` concurrency limiter
- Reduces polling cycle wall-clock time from ~N×RTT to ~⌈N/10⌉×RTT
- Per-task exception handling prevents one API failure from aborting the entire cycle
- Results collected into `ConcurrentBag` and processed sequentially to preserve `SingleWriter` channel semantics

## Test plan
- [ ] Verify concurrent polling with multiple tracked invoices
- [ ] Confirm paid/expired/null invoice handling still works correctly
- [ ] Check that API rate limiting is not triggered with the concurrency cap of 10

Closes #3