### PR TITLE
Add tests for concurrent invoice polling

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -177,6 +178,139 @@ public class BareBitcoinListenerTests : IDisposable
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
             new BareBitcoinListener(client, invoiceService, NullLogger.Instance, channelCapacity: capacity));
         Assert.Equal("channelCapacity", ex.ParamName);
+    }
+
+    [Fact]
+    public async Task PartialPollFailure_SuccessfulInvoiceIsDelivered_FailedInvoiceRemainsTracked()
+    {
+        await using var invoiceService = new BareBitcoinInvoiceService(NullLogger.Instance, InvoiceFilePath);
+        await invoiceService.TrackInvoice("inv-ok");
+        await invoiceService.TrackInvoice("inv-fail");
+
+        // Signal when first poll cycle completes so we can add a second invoice
+        // to prove the listener survives the exception and keeps polling
+        var firstCycleOkPolled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var client = new FakeLightningClient((invoiceId, _) =>
+        {
+            if (invoiceId == "inv-fail")
+                throw new Exception("Simulated API failure");
+            if (invoiceId == "inv-ok")
+                firstCycleOkPolled.TrySetResult();
+            return Task.FromResult<LightningInvoice?>(PaidInvoice(invoiceId));
+        });
+
+        using var listener = new BareBitcoinListener(client, invoiceService, NullLogger.Instance, channelCapacity: 10);
+
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        // Wait for first successful invoice
+        var first = await listener.WaitInvoice(cts.Token);
+        Assert.Equal("inv-ok", first.Id);
+        Assert.Equal(LightningInvoiceStatus.Paid, first.Status);
+
+        // Ensure the poll cycle that processed inv-ok has completed
+        await firstCycleOkPolled.Task.WaitAsync(TestTimeout);
+
+        // Add a second invoice after the failure — proves the listener survived the exception
+        await invoiceService.TrackInvoice("inv-ok-2");
+        var second = await listener.WaitInvoice(cts.Token);
+        Assert.Equal("inv-ok-2", second.Id);
+
+        // Failed invoice should remain tracked for retry
+        var remaining = await invoiceService.GetTrackedInvoices();
+        Assert.Contains("inv-fail", remaining);
+        Assert.DoesNotContain("inv-ok", remaining);
+        Assert.DoesNotContain("inv-ok-2", remaining);
+    }
+
+    [Fact]
+    public async Task CancellationDuringConcurrentPolling_ShutsDownGracefully()
+    {
+        await using var invoiceService = new BareBitcoinInvoiceService(NullLogger.Instance, InvoiceFilePath);
+        for (var i = 1; i <= 5; i++)
+            await invoiceService.TrackInvoice($"inv-{i}");
+
+        var pollsStarted = 0;
+        var cancellationsObserved = 0;
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocker = new TaskCompletionSource<LightningInvoice?>();
+
+        var client = new FakeLightningClient((_, ct) =>
+        {
+            var count = Interlocked.Increment(ref pollsStarted);
+            if (count >= 5)
+                allStarted.TrySetResult();
+            ct.Register(() =>
+            {
+                blocker.TrySetCanceled(ct);
+                if (Interlocked.Increment(ref cancellationsObserved) >= 5)
+                    allCancelled.TrySetResult();
+            });
+            return blocker.Task;
+        });
+
+        using var listener = new BareBitcoinListener(client, invoiceService, NullLogger.Instance, channelCapacity: 10);
+
+        // Wait until all 5 concurrent polls are in-flight
+        await allStarted.Task.WaitAsync(TestTimeout);
+
+        // Dispose cancels _cts, which should propagate to all concurrent polls
+        listener.Dispose();
+
+        // Verify cancellation propagated to all in-flight polls
+        await allCancelled.Task.WaitAsync(TestTimeout);
+        Assert.Equal(5, Volatile.Read(ref cancellationsObserved));
+        Assert.True(listener.IsDisposed);
+    }
+
+    [Fact]
+    public async Task ConcurrentPolling_CompletesInParallel_NotSequentially()
+    {
+        await using var invoiceService = new BareBitcoinInvoiceService(NullLogger.Instance, InvoiceFilePath);
+        for (var i = 1; i <= 10; i++)
+            await invoiceService.TrackInvoice($"inv-{i}");
+
+        // Track the peak number of concurrently in-flight polls using a barrier pattern.
+        // This proves structural concurrency without relying on wall-clock timing.
+        var currentInFlight = 0;
+        var peakInFlight = 0;
+
+        var client = new FakeLightningClient(async (invoiceId, ct) =>
+        {
+            var current = Interlocked.Increment(ref currentInFlight);
+
+            // Atomically update peak if we exceeded it
+            int snapshot;
+            do
+            {
+                snapshot = Volatile.Read(ref peakInFlight);
+                if (current <= snapshot) break;
+            } while (Interlocked.CompareExchange(ref peakInFlight, current, snapshot) != snapshot);
+
+            // Small delay to keep polls in-flight long enough for overlap
+            await Task.Delay(100, ct);
+            Interlocked.Decrement(ref currentInFlight);
+            return PaidInvoice(invoiceId);
+        });
+
+        using var listener = new BareBitcoinListener(client, invoiceService, NullLogger.Instance, channelCapacity: 20);
+
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var received = new HashSet<string>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var invoice = await listener.WaitInvoice(cts.Token);
+            received.Add(invoice.Id);
+        }
+
+        Assert.Equal(10, received.Count);
+        // With 10 invoices and MaxPollConcurrency=10, all should be in-flight simultaneously.
+        // Assert at least 2 overlapping polls to prove concurrency (sequential would always be 1).
+        Assert.True(Volatile.Read(ref peakInFlight) >= 2,
+            $"Peak concurrent polls was {peakInFlight}, expected >= 2 to prove parallel execution");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds three tests for the concurrent polling behavior introduced in #23
- **Partial failure**: verifies that when `GetInvoice` throws for one invoice, the successful invoice is still delivered and the failed one remains tracked for retry
- **Cancellation during concurrent polling**: verifies graceful shutdown when multiple polls are in-flight simultaneously
- **Concurrency verification**: proves polling runs in parallel by timing 10 invoices with artificial delay

Closes #24