### PR TITLE
CI: Fix flaky Release build from missing static web asset manifests

### DIFF
--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -38,5 +38,15 @@ jobs:
       - name: Build plugin in Release
         run: dotnet build plugin/BTCPayServer.Plugins.BareBitcoin.csproj -c Release
 
+      - name: Ensure static web asset manifests exist
+        run: |
+          dir="submodules/btcpayserver/BTCPayServer/obj/Release/net8.0"
+          for f in staticwebassets.development.json staticwebassets.build.endpoints.json; do
+            [ -f "$dir/$f" ] || echo '{}' > "$dir/$f"
+          done
+
+      - name: Build tests in Release
+        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release
+
       - name: Run tests
-        run: dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release
+        run: dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release --no-build


### PR DESCRIPTION
## Summary
- Pin SDK to .NET 8 in CI via `global.json` to avoid .NET 10 SDK conflicts
- Create stub static web asset manifest files after plugin build to prevent intermittent MSB3030 errors when building the test project

The BTCPayServer submodule's Release build intermittently skips generating `staticwebassets.development.json` and `staticwebassets.build.endpoints.json`, causing the test project build to fail. This was affecting all branches.

## Test plan
- [x] Verify Plugin Builder Compatibility workflow passes