### PR TITLE
CI: Fix push trigger to target master instead of main

### DIFF
--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
     tags:
       - "v*"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- The workflow's push trigger was targeting `main`, but the repo's default branch is `master`
- CI never ran on pushes to master after PR merges
- This fixes it so post-merge CI runs on the correct branch

## Also done (outside this PR)

- Added branch protection on `master` requiring the `build` check to pass before merging
- Created issues #47–#52 for unaddressed bot findings from today's merged PRs

## Test plan

- [ ] Verify CI triggers on push to master after this PR merges
- [ ] Verify PRs are blocked from merging when `build` check fails