### PR TITLE
Add listener coverage for expired and missing invoices

### DIFF
--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -36,7 +36,7 @@ jobs:
         run: dotnet --info
 
       - name: Build tests in Release
-        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release
+        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release -m:1
 
       - name: Ensure static web asset manifests exist
         run: |
@@ -46,7 +46,7 @@ jobs:
           done
 
       - name: Build tests in Release
-        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release
+        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release -m:1
 
       - name: Run tests
         run: dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release --no-build

--- a/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
@@ -492,15 +492,15 @@ public class BareBitcoinListenerTests : IDisposable
 
     private static async Task WaitUntilInvoiceIsUntracked(BareBitcoinInvoiceService invoiceService, string invoiceId)
     {
-        using var cts = new CancellationTokenSource(TestTimeout);
+        var deadline = DateTimeOffset.UtcNow + TestTimeout;
 
-        while (!cts.Token.IsCancellationRequested)
+        while (DateTimeOffset.UtcNow < deadline)
         {
-            var trackedInvoices = await invoiceService.GetTrackedInvoices(cts.Token);
+            var trackedInvoices = await invoiceService.GetTrackedInvoices();
             if (!trackedInvoices.Contains(invoiceId))
                 return;
 
-            await Task.Delay(50, cts.Token);
+            await Task.Delay(50);
         }
 
         throw new TimeoutException($"Invoice {invoiceId} was still tracked after {TestTimeout.TotalSeconds} seconds.");


### PR DESCRIPTION
## Summary
- add listener tests for expired invoices being untracked without delivery
- add listener tests for missing invoices being untracked without delivery
- add a small polling helper to wait for untracking in a deterministic way

Closes #38

## Validation
- `dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj`
- `dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj --filter BareBitcoinListenerTests` *(blocked locally: this machine lacks the .NET 8 runtime, and the test host crashes when forced onto .NET 9)*