### PR TITLE
Simplify plugin compatibility workflow

### DIFF
--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -35,12 +35,10 @@ jobs:
       - name: Show environment
         run: dotnet --info
 
-      - name: Build tests in Release
-        run: dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release -m:1
-
       - name: Ensure static web asset manifests exist
         run: |
           dir="submodules/btcpayserver/BTCPayServer/obj/Release/net8.0"
+          mkdir -p "$dir"
           for f in staticwebassets.development.json staticwebassets.build.endpoints.json; do
             [ -f "$dir/$f" ] || echo '{}' > "$dir/$f"
           done


### PR DESCRIPTION
## Summary
- remove the redundant first test-project build from the compatibility workflow
- create the static web asset manifest directory before writing stubs
- keep a single serialized Release build for deterministic CI

Closes #56
Closes #49

## Validation
- `dotnet build BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj -c Release -m:1`
- CI will validate the streamlined workflow on GitHub Actions