### PR TITLE
Add RunContinuationsAsynchronously to blocker TCS

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinListenerTests.cs
@@ -185,7 +185,7 @@ public class BareBitcoinListenerTests : IDisposable
 
         // Signal when the polling loop reaches GetInvoice
         var reachedGetInvoice = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var blocker = new TaskCompletionSource<LightningInvoice?>();
+        var blocker = new TaskCompletionSource<LightningInvoice?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var client = new FakeLightningClient((_, ct) =>
         {


### PR DESCRIPTION
## Summary

- Add `TaskCreationOptions.RunContinuationsAsynchronously` to the `blocker` TaskCompletionSource in `CancellationDuringConcurrentPolling_ShutsDownGracefully`
- Prevents potential deadlocks when `TrySetCanceled` is called inside a synchronous `ct.Register` callback, which could run continuations inline on the cancelling thread

Closes #52