### PR TITLE
Wrap timer callback to catch synchronous exceptions

### DIFF
--- a/plugin/Services/BareBitcoinInvoiceService.cs
+++ b/plugin/Services/BareBitcoinInvoiceService.cs
@@ -35,9 +35,9 @@ public class BareBitcoinInvoiceService : IBareBitcoinInvoiceService, IAsyncDispo
     {
         _logger = logger;
         _dataFilePath = dataFilePath;
-        _flushTimer = new Timer(_ =>
+        _flushTimer = new Timer(async _ =>
         {
-            try { _ = FlushAsync(); }
+            try { await FlushAsync().ConfigureAwait(false); }
             catch (Exception ex) { _logger.LogError(ex, "Unhandled exception in flush timer callback"); }
         }, null, Timeout.Infinite, Timeout.Infinite);
         LoadFromDisk();


### PR DESCRIPTION
## Summary
- Wraps the `Timer` callback in `BareBitcoinInvoiceService` with a try-catch to guard against synchronous exceptions from `FlushAsync()`
- Any unexpected synchronous exception is now logged instead of going unobserved

Closes #69