### PR TITLE
Add eviction for stale LogThrottle state entries

### DIFF
--- a/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
+++ b/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
@@ -200,6 +200,80 @@ public class LogThrottleTests
         Assert.Contains("Template inv-1", _logger.Entries[0].Message);
     }
 
+    [Fact]
+    public void StaleEntries_AreEvictedWhenThresholdExceeded()
+    {
+        var throttle = CreateThrottle();
+
+        // Add 11 distinct templates to exceed the threshold
+        for (var i = 0; i < 11; i++)
+            throttle.LogWarning(new IOException("disk"), $"Template{i} {{Id}}", "inv");
+
+        Assert.Equal(11, throttle.StateCount);
+
+        // Advance past the suppression window so all entries become stale
+        Advance(_window);
+
+        // Next call triggers eviction — stale entries are removed, only the new one remains
+        throttle.LogWarning(new IOException("disk"), "Fresh {Id}", "inv");
+        Assert.Equal(1, throttle.StateCount);
+        Assert.NotNull(throttle.GetState("Fresh {Id}"));
+    }
+
+    [Fact]
+    public void ActiveEntries_AreNotEvicted()
+    {
+        var throttle = CreateThrottle();
+
+        for (var i = 0; i < 11; i++)
+            throttle.LogWarning(new IOException("disk"), $"Template{i} {{Id}}", "inv");
+
+        // Don't advance clock — entries are still within their window
+        throttle.LogWarning(new IOException("disk"), "Extra {Id}", "inv");
+        Assert.Equal(12, throttle.StateCount);
+    }
+
+    [Fact]
+    public void Eviction_FlushesSuppressedCountSummary()
+    {
+        var throttle = CreateThrottle();
+
+        // Create 11 templates, each with a suppressed call
+        for (var i = 0; i < 11; i++)
+        {
+            throttle.LogWarning(new IOException("disk"), $"Template{i} {{Id}}", "inv");
+            Advance(TimeSpan.FromSeconds(1));
+            throttle.LogWarning(new IOException("disk"), $"Template{i} {{Id}}", "inv"); // suppressed
+        }
+
+        _logger.Entries.Clear();
+
+        // Advance past window and trigger eviction
+        Advance(_window);
+        throttle.LogWarning(new IOException("disk"), "Fresh {Id}", "inv");
+
+        // Each of the 11 stale entries had SuppressedCount=1, so 11 summary logs + 1 fresh warning
+        var summaries = _logger.Entries.FindAll(e => e.Message.Contains("Suppressed 1"));
+        Assert.Equal(11, summaries.Count);
+    }
+
+    [Fact]
+    public void BelowThreshold_NoEvictionOccurs()
+    {
+        var throttle = CreateThrottle();
+
+        throttle.LogWarning(new IOException("disk"), "A {Id}", "inv");
+        throttle.LogWarning(new IOException("disk"), "B {Id}", "inv");
+        throttle.LogWarning(new IOException("disk"), "C {Id}", "inv");
+
+        // Advance past window — entries are stale but count (3) is below threshold
+        Advance(_window);
+        throttle.LogWarning(new IOException("disk"), "A {Id}", "inv");
+
+        // All 3 entries still present — no eviction triggered
+        Assert.Equal(3, throttle.StateCount);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/plugin/Services/LogThrottle.cs
+++ b/plugin/Services/LogThrottle.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -12,6 +13,8 @@ namespace BTCPayServer.Plugins.BareBitcoin.Services;
 /// </summary>
 internal class LogThrottle
 {
+    private const int MaxEntries = 10;
+
     private readonly ILogger _logger;
     private readonly TimeSpan _suppressionWindow;
     private readonly Func<long> _clock;
@@ -35,8 +38,9 @@ internal class LogThrottle
 
     /// <summary>
     /// Logs a message at the specified level, throttling repeated calls with the same
-    /// <paramref name="messageTemplate"/>. The template must be a static string literal;
-    /// dynamic templates will cause unbounded memory growth.
+    /// <paramref name="messageTemplate"/>. The template should be a static string literal.
+    /// Dynamic templates are tolerated—stale entries are evicted—but active-window growth
+    /// is unbounded; prefer static templates.
     /// </summary>
     public void Log(LogLevel logLevel, Exception? ex, string messageTemplate, params object[] args)
     {
@@ -74,6 +78,41 @@ internal class LogThrottle
                 state.SuppressedCount++;
             }
         }
+
+        if (_states.Count > MaxEntries)
+            EvictStaleEntries();
+    }
+
+    private void EvictStaleEntries()
+    {
+        var now = _clock();
+        foreach (var kvp in _states)
+        {
+            var state = kvp.Value;
+            lock (state.Lock)
+            {
+                if (state.IsFirstCall)
+                    continue;
+
+                var elapsed = Stopwatch.GetElapsedTime(state.WindowStart, now);
+                if (elapsed >= _suppressionWindow)
+                {
+                    // Remove only if the value still matches the instance we checked,
+                    // avoiding accidental removal of a concurrently recreated entry.
+                    // Only the thread that successfully removes the entry emits the summary,
+                    // preventing duplicate logs under concurrent eviction.
+                    if (!((ICollection<KeyValuePair<string, ThrottleState>>)_states).Remove(kvp))
+                        continue;
+
+                    if (state.SuppressedCount > 0)
+                    {
+                        _logger.LogWarning(
+                            "Suppressed {SuppressedCount} repeated message(s) for \"{MessageTemplate}\" over the last {Window}",
+                            state.SuppressedCount, kvp.Key, _suppressionWindow);
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -96,4 +135,9 @@ internal class LogThrottle
         _states.TryGetValue(messageTemplate, out var state);
         return state;
     }
+
+    /// <summary>
+    /// Returns the number of tracked message templates (for testing).
+    /// </summary>
+    internal int StateCount => _states.Count;
 }


### PR DESCRIPTION
## Summary
- Adds threshold-guarded opportunistic eviction to `LogThrottle` — when `_states.Count` exceeds 10, stale entries (expired suppression window) are removed on the next `LogWarning` call
- In normal operation (3 static template call sites), the eviction scan never triggers
- Includes 3 new tests covering eviction behavior, active entry preservation, and below-threshold no-op

Closes #63