### PR TITLE
Log unobserved exceptions from timer-triggered FlushAsync

### DIFF
--- a/plugin/Services/BareBitcoinInvoiceService.cs
+++ b/plugin/Services/BareBitcoinInvoiceService.cs
@@ -108,56 +108,10 @@ public class BareBitcoinInvoiceService : IBareBitcoinInvoiceService, IAsyncDispo
     /// </summary>
     public async Task FlushAsync()
     {
-        string json;
-        long version;
-
         try
         {
-            await _invoiceTrackingLock.WaitAsync();
-        }
-        catch (ObjectDisposedException)
-        {
-            return;
-        }
-
-        try
-        {
-            if (!_dirty) return;
-            json = JsonConvert.SerializeObject(_trackedInvoiceRegistry);
-            _dirty = false;
-            version = ++_snapshotVersion;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to serialize tracked invoices");
-            if (!_disposed)
-                ScheduleFlush();
-            return;
-        }
-        finally
-        {
-            try { _invoiceTrackingLock.Release(); }
-            catch (ObjectDisposedException) { }
-        }
-
-        try
-        {
-            await _diskWriteLock.WaitAsync();
-        }
-        catch (ObjectDisposedException)
-        {
-            return;
-        }
-
-        try
-        {
-            if (version <= _writtenVersion) return;
-            await SaveToDiskAsync(json);
-            _writtenVersion = version;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to flush tracked invoices to disk");
+            string json;
+            long version;
 
             try
             {
@@ -170,20 +124,73 @@ public class BareBitcoinInvoiceService : IBareBitcoinInvoiceService, IAsyncDispo
 
             try
             {
-                _dirty = true;
+                if (!_dirty) return;
+                json = JsonConvert.SerializeObject(_trackedInvoiceRegistry);
+                _dirty = false;
+                version = ++_snapshotVersion;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to serialize tracked invoices");
                 if (!_disposed)
                     ScheduleFlush();
+                return;
             }
             finally
             {
                 try { _invoiceTrackingLock.Release(); }
                 catch (ObjectDisposedException) { }
             }
+
+            try
+            {
+                await _diskWriteLock.WaitAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+
+            try
+            {
+                if (version <= _writtenVersion) return;
+                await SaveToDiskAsync(json);
+                _writtenVersion = version;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to flush tracked invoices to disk");
+
+                try
+                {
+                    await _invoiceTrackingLock.WaitAsync();
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+
+                try
+                {
+                    _dirty = true;
+                    if (!_disposed)
+                        ScheduleFlush();
+                }
+                finally
+                {
+                    try { _invoiceTrackingLock.Release(); }
+                    catch (ObjectDisposedException) { }
+                }
+            }
+            finally
+            {
+                try { _diskWriteLock.Release(); }
+                catch (ObjectDisposedException) { }
+            }
         }
-        finally
+        catch (Exception ex)
         {
-            try { _diskWriteLock.Release(); }
-            catch (ObjectDisposedException) { }
+            _logger.LogError(ex, "Unhandled exception in FlushAsync");
         }
     }
 


### PR DESCRIPTION
## Summary
- Wraps the entire body of `FlushAsync` in a top-level try-catch that logs unexpected exceptions
- Acts as a safety net for the fire-and-forget `_ = FlushAsync()` call from the debounce timer callback
- Existing granular error handling remains intact

Closes #72