### PR TITLE
Add CreateInvoice cancellation propagation test

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -124,6 +124,20 @@ public class BareBitcoinLightningClientTests
     }
 
     [Fact]
+    public async Task CreateInvoice_PropagatesOperationCanceledException_FromTrackInvoice()
+    {
+        var invoiceService = new ThrowingInvoiceService(
+            trackException: new OperationCanceledException("token cancelled"));
+
+        var handler = new FakeMessageHandler(CreateInvoiceApiJson());
+        var client = CreateClient(handler, invoiceService);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => client.CreateInvoice(
+                new CreateInvoiceParams(LightMoney.Satoshis(1000), "test", TimeSpan.FromHours(1))));
+    }
+
+    [Fact]
     public async Task GetInvoice_LogsWarning_WhenTrackInvoiceThrowsIOException()
     {
         var logger = new CapturingLogger();


### PR DESCRIPTION
## Summary
- Add `CreateInvoice_PropagatesOperationCanceledException_FromTrackInvoice` test
- Mirrors the existing `GetInvoice_PropagatesOperationCanceledException_FromTrackInvoice` test pattern
- Verifies `OperationCanceledException` from `TrackInvoice` is not swallowed by the `IOException` catch block

Closes #76