### PR TITLE
Use monotonic clock for LogThrottle windowing

### DIFF
--- a/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
+++ b/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
@@ -119,6 +119,18 @@ public class LogThrottleTests
         Assert.DoesNotContain("Suppressed", _logger.Entries[1].Message);
     }
 
+    [Fact]
+    public void FirstCall_LogsImmediately_WhenClockStartsAtZero()
+    {
+        long now = 0;
+        var throttle = new LogThrottle(_logger, _window, () => now);
+
+        throttle.LogWarning(new IOException("disk"), "Template {Id}", "inv-1");
+
+        Assert.Single(_logger.Entries);
+        Assert.Contains("Template inv-1", _logger.Entries[0].Message);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/plugin/Services/LogThrottle.cs
+++ b/plugin/Services/LogThrottle.cs
@@ -21,6 +21,7 @@ internal class LogThrottle
     internal class ThrottleState
     {
         public long WindowStart;
+        public bool IsFirstCall = true;
         public int SuppressedCount;
         public readonly object Lock = new();
     }
@@ -46,7 +47,7 @@ internal class LogThrottle
             var now = _clock();
             var elapsed = Stopwatch.GetElapsedTime(state.WindowStart, now);
 
-            if (elapsed >= _suppressionWindow)
+            if (state.IsFirstCall || elapsed >= _suppressionWindow)
             {
                 // Window expired (or first call) — emit summary if anything was suppressed
                 if (state.SuppressedCount > 0)
@@ -58,6 +59,7 @@ internal class LogThrottle
 
                 // Log the actual warning and start a new window
                 _logger.LogWarning(ex, messageTemplate, args);
+                state.IsFirstCall = false;
                 state.WindowStart = now;
                 state.SuppressedCount = 0;
             }


### PR DESCRIPTION
## Summary
- Replace `DateTimeOffset` (wall-clock) with `Stopwatch.GetTimestamp()` (monotonic) for suppression window tracking in `LogThrottle`
- Remove the backward clock jump guard (`elapsed < TimeSpan.Zero`) since monotonic clocks don't go backward
- Remove two backward-clock-jump tests that are no longer applicable

Closes #91