### PR TITLE
Use monotonic clock in LogThrottle

### DIFF
--- a/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
+++ b/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
@@ -119,6 +119,19 @@ public class LogThrottleTests
         Assert.DoesNotContain("Suppressed", _logger.Entries[1].Message);
     }
 
+    [Fact]
+    public void FirstCall_LogsImmediately_EvenWithLowTimestamp()
+    {
+        // Simulate early boot: timestamp near zero, less than the suppression window
+        long earlyBootNow = (long)(30 * Stopwatch.Frequency); // 30 seconds after boot
+        var throttle = new LogThrottle(_logger, _window, () => earlyBootNow);
+
+        throttle.LogWarning(new IOException("disk"), "Template {Id}", "inv-1");
+
+        Assert.Single(_logger.Entries);
+        Assert.Contains("Template inv-1", _logger.Entries[0].Message);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]

--- a/plugin/Services/LogThrottle.cs
+++ b/plugin/Services/LogThrottle.cs
@@ -20,6 +20,7 @@ internal class LogThrottle
     internal class ThrottleState
     {
         public long WindowStart;
+        public bool IsFirstCall = true;
         public int SuppressedCount;
         public readonly object Lock = new();
     }
@@ -48,7 +49,7 @@ internal class LogThrottle
             var now = _clock();
             var elapsed = Stopwatch.GetElapsedTime(state.WindowStart, now);
 
-            if (elapsed >= _suppressionWindow)
+            if (state.IsFirstCall || elapsed >= _suppressionWindow)
             {
                 // Window expired (or first call) — emit summary if anything was suppressed
                 if (state.SuppressedCount > 0)
@@ -61,6 +62,7 @@ internal class LogThrottle
                 // Log the actual warning and start a new window
                 _logger.LogWarning(ex, messageTemplate, args);
                 state.WindowStart = now;
+                state.IsFirstCall = false;
                 state.SuppressedCount = 0;
             }
             else


### PR DESCRIPTION
## Summary

- Replace `DateTimeOffset.UtcNow` (wall clock) with `Stopwatch.GetTimestamp` (monotonic) for LogThrottle suppression window timing
- Remove the backward clock jump guard (`elapsed < TimeSpan.Zero`) from #86, as monotonic time cannot go backward
- Remove the two backward clock jump tests that are no longer applicable

## Test plan

- [ ] Verify all remaining LogThrottle tests pass
- [ ] Verify no other code references the old `Func<DateTimeOffset>` clock signature

Closes #91