### PR TITLE
Add hard cap for LogThrottle active entries

### DIFF
--- a/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
+++ b/BTCPayServer.Plugins.Tests/LogThrottleTests.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using BTCPayServer.Plugins.BareBitcoin.Services;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -237,6 +240,27 @@ public class LogThrottleTests
 
         Assert.NotNull(throttle.GetState("Template A"));
         Assert.NotNull(throttle.GetState("Template B"));
+    }
+
+    [Fact]
+    public void MaxEntries_ConcurrentTemplates_NeverExceedsCap()
+    {
+        const int cap = 10;
+        const int templateCount = 50;
+        var throttle = new LogThrottle(_logger, _window, () => _now, maxEntries: cap);
+        var barrier = new Barrier(templateCount);
+
+        var tasks = Enumerable.Range(0, templateCount).Select(i => Task.Run(() =>
+        {
+            barrier.SignalAndWait(TimeSpan.FromSeconds(5));
+            throttle.LogWarning(null, $"Template {i}");
+        })).ToArray();
+
+        Task.WaitAll(tasks);
+
+        // Count surviving entries — must never exceed the cap
+        int count = Enumerable.Range(0, templateCount).Count(i => throttle.GetState($"Template {i}") != null);
+        Assert.True(count <= cap, $"Expected at most {cap} entries but found {count}");
     }
 
     [Theory]

--- a/plugin/Services/LogThrottle.cs
+++ b/plugin/Services/LogThrottle.cs
@@ -16,6 +16,7 @@ internal class LogThrottle
     private readonly TimeSpan _suppressionWindow;
     private readonly Func<long> _clock;
     private readonly int _maxEntries;
+    private readonly object _evictionLock = new();
     private readonly ConcurrentDictionary<string, ThrottleState> _states = new();
 
     internal class ThrottleState
@@ -46,27 +47,40 @@ internal class LogThrottle
     {
         if (!_logger.IsEnabled(logLevel)) return;
 
-        // Evict oldest entry if at capacity and this is a new template
-        if (_states.Count >= _maxEntries && !_states.ContainsKey(messageTemplate))
+        ThrottleState state;
+
+        // Fast path: template already tracked — no eviction needed
+        if (_states.TryGetValue(messageTemplate, out state!))
+            goto throttle;
+
+        // Slow path: new template — serialize eviction + add to enforce cap
+        lock (_evictionLock)
         {
-            string? oldestKey = null;
-            long oldestWindow = long.MaxValue;
-            foreach (var kvp in _states)
+            // Re-check after acquiring lock (another thread may have added it)
+            if (!_states.TryGetValue(messageTemplate, out state!))
             {
-                if (kvp.Value.WindowStart < oldestWindow)
+                if (_states.Count >= _maxEntries)
                 {
-                    oldestWindow = kvp.Value.WindowStart;
-                    oldestKey = kvp.Key;
+                    string? oldestKey = null;
+                    long oldestWindow = long.MaxValue;
+                    foreach (var kvp in _states)
+                    {
+                        if (kvp.Value.WindowStart < oldestWindow)
+                        {
+                            oldestWindow = kvp.Value.WindowStart;
+                            oldestKey = kvp.Key;
+                        }
+                    }
+                    if (oldestKey != null)
+                        _states.TryRemove(oldestKey, out _);
                 }
+
+                state = new ThrottleState { WindowStart = 0 };
+                _states[messageTemplate] = state;
             }
-            if (oldestKey != null)
-                _states.TryRemove(oldestKey, out _);
         }
 
-        var state = _states.GetOrAdd(messageTemplate, _ => new ThrottleState
-        {
-            WindowStart = 0
-        });
+        throttle:
 
         lock (state.Lock)
         {


### PR DESCRIPTION
## Summary
- Adds `maxEntries` constructor parameter (default 100) to `LogThrottle`
- When capacity is reached and a new template arrives, evicts the entry with the oldest `WindowStart`
- Prevents unbounded memory growth if dynamic templates are ever introduced

## Test plan
- [x] New test: oldest entry evicted when maxEntries reached
- [x] New test: existing templates don't trigger eviction
- [x] New test: constructor rejects non-positive maxEntries
- [x] All 18 LogThrottle tests pass

Closes #113