### PR TITLE
Promote flush failure log level from Warning to Error

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinInvoiceServiceTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinInvoiceServiceTests.cs
@@ -129,7 +129,7 @@ public class BareBitcoinInvoiceServiceTests : IDisposable
 
         Assert.NotNull(service.LastFlushException);
         Assert.IsType<IOException>(service.LastFlushException);
-        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
     }
 
     [Fact]
@@ -369,11 +369,11 @@ public class BareBitcoinInvoiceServiceTests : IDisposable
         for (var i = 0; i < 10; i++)
             await service.FlushAsync();
 
-        // First call logs a warning, subsequent calls within the 5-minute window are suppressed.
-        var flushWarnings = logger.Entries
-            .Where(e => e.Level == LogLevel.Warning && e.Message.Contains("Failed to flush tracked invoices to disk"))
+        // First call logs an error, subsequent calls within the 5-minute window are suppressed.
+        var flushErrors = logger.Entries
+            .Where(e => e.Level == LogLevel.Error && e.Message.Contains("Failed to flush tracked invoices to disk"))
             .ToList();
-        Assert.Single(flushWarnings);
+        Assert.Single(flushErrors);
     }
 
     private class FailingSaveService : BareBitcoinInvoiceService

--- a/plugin/Services/BareBitcoinInvoiceService.cs
+++ b/plugin/Services/BareBitcoinInvoiceService.cs
@@ -141,7 +141,7 @@ public class BareBitcoinInvoiceService : IBareBitcoinInvoiceService, IAsyncDispo
             {
                 Interlocked.Increment(ref _consecutiveFlushFailures);
                 Volatile.Write(ref _lastFlushException, ex);
-                _logThrottle.LogWarning(ex, "Failed to serialize tracked invoices");
+                _logThrottle.LogError(ex, "Failed to serialize tracked invoices");
                 if (!_disposed)
                     ScheduleFlush(GetFlushBackoff());
                 return;
@@ -164,7 +164,7 @@ public class BareBitcoinInvoiceService : IBareBitcoinInvoiceService, IAsyncDispo
             {
                 Interlocked.Increment(ref _consecutiveFlushFailures);
                 Volatile.Write(ref _lastFlushException, ex);
-                _logThrottle.LogWarning(ex, "Failed to flush tracked invoices to disk");
+                _logThrottle.LogError(ex, "Failed to flush tracked invoices to disk");
                 await MarkDirtyAndRescheduleAsync();
             }
             finally


### PR DESCRIPTION
## Summary
- Change `_logThrottle.LogWarning` to `_logThrottle.LogError` for both flush failure paths (serialization and disk I/O) in `FlushAsync`
- Update test assertions to expect `LogLevel.Error` instead of `LogLevel.Warning`
- Flush failures risk losing tracked invoice state on restart — Error level ensures operators are alerted, consistent with the timer-callback and dispose-time error paths

Closes #110