### PR TITLE
Add test coverage for GetInvoice retry/backoff paths

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -310,6 +310,7 @@ public class BareBitcoinLightningClientTests
         var ex = await Assert.ThrowsAsync<RateLimitedException>(
             () => client.GetInvoice("inv-deferred"));
         Assert.NotNull(ex.RetryAfter);
+        Assert.True(ex.RetryAfter > TimeSpan.Zero, "RetryAfter should be positive");
         Assert.Equal(0, attemptCount);
     }
 

--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -316,15 +316,19 @@ public class BareBitcoinLightningClientTests
     [Fact]
     public async Task GetInvoice_RetriesTransientError_ThenSucceeds()
     {
+        var attemptCount = 0;
         var invoiceService = new ThrowingInvoiceService();
         var handler = new CountingPerInvoiceHandler((invoiceId, attempt) =>
-            attempt == 1
+        {
+            Interlocked.Increment(ref attemptCount);
+            return attempt == 1
                 ? Task.FromException<HttpResponseMessage>(
                     new HttpRequestException("connection refused"))
                 : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(ApiJson("INVOICE_STATUS_UNPAID"), Encoding.UTF8, "application/json")
-                }));
+                });
+        });
 
         var client = CreateClient(handler, invoiceService, maxRetries: 3);
 
@@ -332,6 +336,7 @@ public class BareBitcoinLightningClientTests
 
         Assert.NotNull(result);
         Assert.Equal("inv-retry", result.Id);
+        Assert.Equal(2, attemptCount);
     }
 
     [Fact]
@@ -352,10 +357,11 @@ public class BareBitcoinLightningClientTests
 
         var client = CreateClient(handler, invoiceService, maxRetries: 3);
 
-        await Assert.ThrowsAsync<RateLimitedException>(
+        var ex = await Assert.ThrowsAsync<RateLimitedException>(
             () => client.GetInvoice("inv-long-wait"));
         Assert.Equal(1, attemptCount);
         Assert.Equal(1, client.RateLimitBackoffCount);
+        Assert.Equal(TimeSpan.FromSeconds(120), ex.RetryAfter);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -290,6 +290,93 @@ public class BareBitcoinLightningClientTests
             () => client.GetInvoice("inv-6"));
     }
 
+    [Fact]
+    public async Task GetInvoice_ThrowsRateLimitedException_WhenBackoffEntryExists()
+    {
+        var attemptCount = 0;
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new PerInvoiceHandler(_ =>
+        {
+            Interlocked.Increment(ref attemptCount);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ApiJson("INVOICE_STATUS_UNPAID"), Encoding.UTF8, "application/json")
+            });
+        });
+
+        var client = CreateClient(handler, invoiceService, maxRetries: 3);
+        client.SetRateLimitBackoff("inv-deferred", DateTimeOffset.UtcNow.AddMinutes(5));
+
+        var ex = await Assert.ThrowsAsync<RateLimitedException>(
+            () => client.GetInvoice("inv-deferred"));
+        Assert.NotNull(ex.RetryAfter);
+        Assert.Equal(0, attemptCount);
+    }
+
+    [Fact]
+    public async Task GetInvoice_RetriesTransientError_ThenSucceeds()
+    {
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new CountingPerInvoiceHandler((invoiceId, attempt) =>
+            attempt == 1
+                ? Task.FromException<HttpResponseMessage>(
+                    new HttpRequestException("connection refused"))
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ApiJson("INVOICE_STATUS_UNPAID"), Encoding.UTF8, "application/json")
+                }));
+
+        var client = CreateClient(handler, invoiceService, maxRetries: 3);
+
+        var result = await client.GetInvoice("inv-retry");
+
+        Assert.NotNull(result);
+        Assert.Equal("inv-retry", result.Id);
+    }
+
+    [Fact]
+    public async Task GetInvoice_ThrowsRateLimitedException_WhenRetryAfterExceedsCap()
+    {
+        var attemptCount = 0;
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new CountingPerInvoiceHandler((_, attempt) =>
+        {
+            Interlocked.Increment(ref attemptCount);
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("rate limited")
+            };
+            response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(TimeSpan.FromSeconds(120));
+            return Task.FromResult(response);
+        });
+
+        var client = CreateClient(handler, invoiceService, maxRetries: 3);
+
+        await Assert.ThrowsAsync<RateLimitedException>(
+            () => client.GetInvoice("inv-long-wait"));
+        Assert.Equal(1, attemptCount);
+        Assert.Equal(1, client.RateLimitBackoffCount);
+    }
+
+    [Fact]
+    public async Task GetInvoice_ThrowsHttpRequestException_WhenMaxRetriesExceeded()
+    {
+        var attemptCount = 0;
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new PerInvoiceHandler(_ =>
+        {
+            Interlocked.Increment(ref attemptCount);
+            return Task.FromException<HttpResponseMessage>(
+                new HttpRequestException("connection refused"));
+        });
+
+        var client = CreateClient(handler, invoiceService, maxRetries: 3);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetInvoice("inv-exhaust"));
+        Assert.Equal(4, attemptCount);
+    }
+
     private sealed class FakeMessageHandler(string responseBody) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(


### PR DESCRIPTION
## Summary
- Adds four direct test cases for `GetInvoice` retry/backoff behavior that was moved from `GetInvoiceWithRetry` in #139
- Tests cover: immediate deferral with pre-seeded backoff, transient error retry, `RateLimitedException` when `Retry-After` exceeds cap, and exception propagation after max retries

Closes #140

## Test plan
- [x] Build compiles successfully
- [ ] All new and existing tests pass in CI