### PR TITLE
Add test: GetInvoice retries 429 within Retry-After cap

### DIFF
--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -384,6 +384,39 @@ public class BareBitcoinLightningClientTests
         Assert.Equal(4, attemptCount);
     }
 
+    [Fact]
+    public async Task GetInvoice_Retries429WithinCap_ThenSucceeds()
+    {
+        var attemptCount = 0;
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new CountingPerInvoiceHandler((_, attempt) =>
+        {
+            Interlocked.Increment(ref attemptCount);
+            if (attempt == 1)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+                {
+                    Content = new StringContent("rate limited")
+                };
+                response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(
+                    TimeSpan.FromMilliseconds(50));
+                return Task.FromResult(response);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ApiJson("INVOICE_STATUS_UNPAID"), Encoding.UTF8, "application/json")
+            });
+        });
+
+        var client = CreateClient(handler, invoiceService, maxRetries: 3);
+
+        var result = await client.GetInvoice("inv-retry-429");
+
+        Assert.NotNull(result);
+        Assert.Equal("inv-retry-429", result.Id);
+        Assert.Equal(2, attemptCount);
+    }
+
     private sealed class FakeMessageHandler(string responseBody) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(

--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -415,6 +415,7 @@ public class BareBitcoinLightningClientTests
         Assert.NotNull(result);
         Assert.Equal("inv-retry-429", result.Id);
         Assert.Equal(2, attemptCount);
+        Assert.Equal(0, client.RateLimitBackoffCount);
     }
 
     private sealed class FakeMessageHandler(string responseBody) : HttpMessageHandler


### PR DESCRIPTION
## Summary
- Adds `GetInvoice_Retries429WithinCap_ThenSucceeds` test verifying that a 429 response with `Retry-After` within the 60s cap is honored and the retry succeeds
- Mirrors the existing `ListInvoices_Retries429_ThenSucceeds` test pattern

Closes #143

## Test plan
- [x] New test passes in isolation
- [x] All 129 existing tests still pass