### PR TITLE
Migrate BareBitcoin plugin to .NET 10 for BTCPay 2.3.7

### DIFF
--- a/.github/workflows/plugin-builder-compat.yml
+++ b/.github/workflows/plugin-builder-compat.yml
@@ -24,20 +24,20 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
-      - name: Pin SDK to .NET 8
-        run: dotnet new globaljson --sdk-version 8.0.0 --roll-forward latestFeature
+      - name: Pin SDK to .NET 10
+        run: dotnet new globaljson --sdk-version 10.0.100 --roll-forward latestFeature
 
       - name: Show environment
         run: dotnet --info
 
       - name: Ensure static web asset manifests exist
         run: |
-          dir="submodules/btcpayserver/BTCPayServer/obj/Release/net8.0"
+          dir="submodules/btcpayserver/BTCPayServer/obj/Release/net10.0"
           mkdir -p "$dir"
           for f in staticwebassets.development.json staticwebassets.build.endpoints.json; do
             [ -f "$dir/$f" ] || echo '{}' > "$dir/$f"

--- a/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
+++ b/BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -22,7 +22,13 @@
             <Private>true</Private>
             <ExcludeAssets>none</ExcludeAssets>
         </ProjectReference>
-        <ProjectReference Include="..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj">
+        <ProjectReference Include="..\..\btcpayserver\BTCPayServer\BTCPayServer.csproj"
+                          Condition="Exists('..\..\btcpayserver\BTCPayServer\BTCPayServer.csproj')">
+            <Properties>StaticWebAssetsEnabled=false</Properties>
+            <Private>false</Private>
+        </ProjectReference>
+        <ProjectReference Include="..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj"
+                          Condition="!Exists('..\..\btcpayserver\BTCPayServer\BTCPayServer.csproj') and Exists('..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj')">
             <Properties>StaticWebAssetsEnabled=false</Properties>
             <Private>false</Private>
         </ProjectReference>

--- a/ConfigBuilder/ConfigBuilder.csproj
+++ b/ConfigBuilder/ConfigBuilder.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/ConfigBuilder/Program.cs
+++ b/ConfigBuilder/Program.cs
@@ -9,13 +9,14 @@ foreach (var plugin in plugins)
     {
         var assemblyConfigurationAttribute = typeof(Program).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
         var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
-        var f = $"{Path.GetFullPath(plugin)}/bin/{buildConfigurationName}/net10.0/{Path.GetFileName(plugin)}.dll";
+        var pluginBinDir = Path.Combine(Path.GetFullPath(plugin), "bin");
+        var pluginDllName = $"{Path.GetFileName(plugin)}.dll";
+        var f = Path.Combine(pluginBinDir, buildConfigurationName ?? "Debug", "net10.0", pluginDllName);
         if (File.Exists(f))
             p += $"{f};";
         else
         {
-            
-            f = $"{Path.GetFullPath(plugin)}/bin/Debug/net10.0/{Path.GetFileName(plugin)}.dll";
+            f = Path.Combine(pluginBinDir, "Debug", "net10.0", pluginDllName);
             if (File.Exists(f))
                 p += $"{f};";
         }
@@ -42,12 +43,16 @@ var content = JsonSerializer.Serialize(new
 Console.WriteLine(content);
 var btcpayRootCandidates = new[]
 {
-    "../../../../btcpayserver/BTCPayServer/appsettings.dev.json",
-    "../../../../submodules/btcpayserver/BTCPayServer/appsettings.dev.json"
+    Path.GetFullPath("../../../../btcpayserver/BTCPayServer"),
+    Path.GetFullPath("../../../../submodules/btcpayserver/BTCPayServer")
 };
 
 var appSettingsPath = btcpayRootCandidates
-    .Select(Path.GetFullPath)
-    .FirstOrDefault(File.Exists) ?? Path.GetFullPath(btcpayRootCandidates[0]);
+    .FirstOrDefault(path => File.Exists(Path.Combine(path, "BTCPayServer.csproj")));
 
-await File.WriteAllTextAsync(appSettingsPath, content);
+if (appSettingsPath is null)
+{
+    throw new DirectoryNotFoundException("Could not locate a BTCPayServer checkout in either the adjacent or submodule layout.");
+}
+
+await File.WriteAllTextAsync(Path.Combine(appSettingsPath, "appsettings.dev.json"), content);

--- a/ConfigBuilder/Program.cs
+++ b/ConfigBuilder/Program.cs
@@ -9,22 +9,20 @@ foreach (var plugin in plugins)
     {
         var assemblyConfigurationAttribute = typeof(Program).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
         var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
-        var x = Directory.GetDirectories(Path.Combine(plugin, "bin"));
-
-        var f = $"{Path.GetFullPath(plugin)}/bin/{buildConfigurationName}/net8.0/{Path.GetFileName(plugin)}.dll";
+        var f = $"{Path.GetFullPath(plugin)}/bin/{buildConfigurationName}/net10.0/{Path.GetFileName(plugin)}.dll";
         if (File.Exists(f))
             p += $"{f};";
         else
         {
             
-            f = $"{Path.GetFullPath(plugin)}/bin/Debug/net8.0/{Path.GetFileName(plugin)}.dll";
+            f = $"{Path.GetFullPath(plugin)}/bin/Debug/net10.0/{Path.GetFileName(plugin)}.dll";
             if (File.Exists(f))
                 p += $"{f};";
         }
         
         // if (x.Any(s => s.EndsWith("Altcoins-Debug")))
         // {
-        //     p += $"{Path.GetFullPath(plugin)}/bin/Altcoins-Debug/net8.0/{Path.GetFileName(plugin)}.dll;";
+        //     p += $"{Path.GetFullPath(plugin)}/bin/Altcoins-Debug/net10.0/{Path.GetFileName(plugin)}.dll;";
         // }
         // else
         // {
@@ -42,4 +40,14 @@ var content = JsonSerializer.Serialize(new
 });
 
 Console.WriteLine(content);
-await File.WriteAllTextAsync("../../../../submodules/BTCPayServer/BTCPayServer/appsettings.dev.json", content);
+var btcpayRootCandidates = new[]
+{
+    "../../../../btcpayserver/BTCPayServer/appsettings.dev.json",
+    "../../../../submodules/btcpayserver/BTCPayServer/appsettings.dev.json"
+};
+
+var appSettingsPath = btcpayRootCandidates
+    .Select(Path.GetFullPath)
+    .FirstOrDefault(File.Exists) ?? Path.GetFullPath(btcpayRootCandidates[0]);
+
+await File.WriteAllTextAsync(appSettingsPath, content);

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Use the provided script to generate your BTCPay Server connection string:
 
 ### Prerequisites
 
-Install the [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0). The plugin and tests target `net8.0` and do not roll forward to newer major versions.
+Install the [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0). The plugin and tests target `net10.0`.
+
+This branch targets BTCPay Server `2.3.7` and newer. For BTCPay Server `2.3.6` and older, keep using an older plugin release that still targets `.NET 8`.
 
 Use one of these BTCPay Server source layouts:
 
@@ -99,7 +101,7 @@ Configure BTCPay Server to load the plugin:
 
 ```shell
 echo '{
-  "DEBUG_PLUGINS": "<absolute-path-to>/plugin/bin/Debug/net8.0/BTCPayServer.Plugins.BareBitcoin.dll"
+  "DEBUG_PLUGINS": "<absolute-path-to>/plugin/bin/Debug/net10.0/BTCPayServer.Plugins.BareBitcoin.dll"
 }' > BTCPayServer/appsettings.dev.json
 ```
 

--- a/plugin/BTCPayServer.Plugins.BareBitcoin.csproj
+++ b/plugin/BTCPayServer.Plugins.BareBitcoin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 

--- a/plugin/BTCPayServer.Plugins.BareBitcoin.csproj
+++ b/plugin/BTCPayServer.Plugins.BareBitcoin.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <!-- Plugin specific properties -->

--- a/plugin/BareBitcoinPlugin.cs
+++ b/plugin/BareBitcoinPlugin.cs
@@ -8,6 +8,7 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Plugins.BareBitcoin.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace BTCPayServer.Plugins.BareBitcoin
 {
@@ -16,7 +17,7 @@ namespace BTCPayServer.Plugins.BareBitcoin
     {
         public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
         {
-            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.0.0" }
+            new() { Identifier = nameof(BTCPayServer), Condition = ">=2.3.7" }
             
         };
 
@@ -25,7 +26,7 @@ namespace BTCPayServer.Plugins.BareBitcoin
             applicationBuilder.AddUIExtension("ln-payment-method-setup-tab", "BareBitcoin/LNPaymentMethodSetupTab");
             applicationBuilder.AddSingleton<BareBitcoinInvoiceService>(provider =>
             {
-                var dataDir = provider.GetRequiredService<DataDirectories>().DataDir;
+                var dataDir = provider.GetRequiredService<IOptions<DataDirectories>>().Value.DataDir;
                 var filePath = Path.Combine(dataDir, "Plugins", "BareBitcoin", "tracked-invoices.json");
                 var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger<BareBitcoinInvoiceService>();
                 return new BareBitcoinInvoiceService(logger, filePath);


### PR DESCRIPTION
Closes #54

## Summary
- migrate the plugin, tests, and config builder from `net8.0` to `net10.0`
- require BTCPay Server `>=2.3.7` in the plugin dependency metadata
- update local development docs and debug plugin path generation for `net10.0`
- fix plugin startup on BTCPay `v2.3.7` by resolving `DataDirectories` via `IOptions<DataDirectories>`

## Verification
- built `plugin/BTCPayServer.Plugins.BareBitcoin.csproj` against BTCPay Server `v2.3.7`
- ran `dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj --no-restore`
- result: `Passed: 129, Failed: 0, Skipped: 0`
- launched BTCPay Server `v2.3.7` locally with `DEBUG_PLUGINS` pointing to the built plugin DLL
- confirmed runtime log contains `Running plugin BTCPayServer.Plugins.BareBitcoin - 1.1.3.0` and BTCPay starts successfully on `http://localhost:14142`

## Notes
- this plugin does not use `GetStoreData`, custom EF tables, or plugin UI controllers/forms, so the BTCPay `2.3.7` migration breakpoints in the maintainer guidance did not apply here
- there are still transitive `NU1903` warnings for `Microsoft.Bcl.Memory 9.0.0`, but they did not block build, test, or runtime startup