### PR TITLE
Update BTCPay submodule for dependency warning investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,14 @@ After the build finishes successfully, it will appear as a **pre-release** in th
 Use the pre-release stage to install and test the plugin on your own BTCPay Server instance before promoting it. Once verified, release the build in the Plugin Builder UI to make it available to all users.
 
 The GitHub release alone does not publish the plugin to the public BTCPay plugin directory.
+
+Before building a release, keep the tracked `submodules/btcpayserver` checkout aligned with the BTCPay Server version declared in the plugin dependency metadata. Plugin Builder uses the submodule layout, so an outdated submodule can surface transitive BTCPay dependency warnings even when local adjacent-checkout builds are clean.
+
+To update it, replace `v2.3.7` with the BTCPay Server version required by `plugin/BTCPayServer.Plugins.BareBitcoin.csproj`:
+
+```shell
+git submodule update --init submodules/btcpayserver
+git -C submodules/btcpayserver fetch --tags
+git -C submodules/btcpayserver checkout v2.3.7
+git add submodules/btcpayserver
+```

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The GitHub release alone does not publish the plugin to the public BTCPay plugin
 
 Before building a release, keep the tracked `submodules/btcpayserver` checkout aligned with the BTCPay Server version declared in the plugin dependency metadata. Plugin Builder uses the submodule layout, so an outdated submodule can surface transitive BTCPay dependency warnings even when local adjacent-checkout builds are clean.
 
-To update it, replace `v2.3.7` with the BTCPay Server version required by `plugin/BTCPayServer.Plugins.BareBitcoin.csproj`:
+To update it, replace `v2.3.7` with the BTCPay Server version required by `plugin/BareBitcoinPlugin.cs`:
 
 ```shell
 git submodule update --init submodules/btcpayserver


### PR DESCRIPTION
## Summary
- update the tracked BTCPay submodule from 5534ddeb to v2.3.7 / ae8120d
- document how to keep the submodule aligned with the plugin's BTCPay dependency metadata before releases

## Investigation
- Plugin Builder uses the submodule layout, and the old submodule commit carried HtmlSanitizer 8.0.838 and MailKit 4.8.0, matching the issue warnings.
- BTCPay v2.3.7 already carries HtmlSanitizer 9.0.892 and MailKit 4.15.1, resolving the issue-specific transitive warnings through the upstream baseline.
- No explicit plugin-side package override is needed because these are BTCPay transitive dependencies, not direct plugin dependencies.

## Verification
- dotnet list plugin/BTCPayServer.Plugins.BareBitcoin.csproj package --vulnerable --include-transitive
- dotnet build plugin/BTCPayServer.Plugins.BareBitcoin.csproj

Note: the current BTCPay baseline still reports unrelated Microsoft.Bcl.Memory 9.0.0 / GHSA-73j8-2gch-69rq warnings.