### PR TITLE
Fix BareBitcoin nonce auth for invoice polling

### DIFF
--- a/.github/workflows/gemini-pull-request-code-review.yml
+++ b/.github/workflows/gemini-pull-request-code-review.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Run Gemini PR Review
         id: gemini
         uses: google-github-actions/run-gemini-cli@9dbec29a20fab3f35017a40ad0eb798a257d4d51 # v0
+        env:
+          GEMINI_CLI_TRUST_WORKSPACE: "true"
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           prompt: |

--- a/BTCPayServer.Plugins.Tests/BareBitcoinApiServiceTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinApiServiceTests.cs
@@ -85,10 +85,14 @@ public class BareBitcoinApiServiceTests
     {
         var activeRequests = 0;
         var maxActiveRequests = 0;
+        var activeRequestsLock = new object();
         var handler = new AsyncRecordingHandler(async _ =>
         {
             var active = Interlocked.Increment(ref activeRequests);
-            maxActiveRequests = Math.Max(maxActiveRequests, active);
+            lock (activeRequestsLock)
+            {
+                maxActiveRequests = Math.Max(maxActiveRequests, active);
+            }
             await Task.Delay(25);
             Interlocked.Decrement(ref activeRequests);
             return new HttpResponseMessage(HttpStatusCode.OK)

--- a/BTCPayServer.Plugins.Tests/BareBitcoinApiServiceTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinApiServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -80,7 +81,47 @@ public class BareBitcoinApiServiceTests
     }
 
     [Fact]
-    public async Task MakeAuthenticatedRequest_ConcurrentCalls_ProduceUniqueNonces()
+    public async Task MakeAuthenticatedRequest_ConcurrentSignedPostCalls_DoNotOverlapForSamePublicKey()
+    {
+        var activeRequests = 0;
+        var maxActiveRequests = 0;
+        var handler = new AsyncRecordingHandler(async _ =>
+        {
+            var active = Interlocked.Increment(ref activeRequests);
+            maxActiveRequests = Math.Max(maxActiveRequests, active);
+            await Task.Delay(25);
+            Interlocked.Decrement(ref activeRequests);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            };
+        });
+        var httpClient = new HttpClient(handler);
+        var publicKey = $"public-key-{Guid.NewGuid()}";
+        var service1 = new BareBitcoinApiService(
+            privateKey: Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            publicKey: publicKey,
+            httpClient: httpClient,
+            logger: NullLogger.Instance);
+        var service2 = new BareBitcoinApiService(
+            privateKey: Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+            publicKey: publicKey,
+            httpClient: httpClient,
+            logger: NullLogger.Instance);
+
+        const int concurrentRequests = 20;
+        var tasks = Enumerable.Range(0, concurrentRequests)
+            .Select(i => (i % 2 == 0 ? service1 : service2).MakeAuthenticatedRequest("POST", "/v1/test", "{}"))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(concurrentRequests, handler.Requests.Length);
+        Assert.Equal(1, maxActiveRequests);
+    }
+
+    [Fact]
+    public async Task MakeAuthenticatedRequest_ConcurrentSignedPostCalls_ProduceMillisecondIncreasingNonces()
     {
         var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -89,36 +130,49 @@ public class BareBitcoinApiServiceTests
         var httpClient = new HttpClient(handler);
         var service = new BareBitcoinApiService(
             privateKey: Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
-            publicKey: "public-key",
+            publicKey: $"public-key-{Guid.NewGuid()}",
             httpClient: httpClient,
             logger: NullLogger.Instance);
 
         const int concurrentRequests = 20;
         var tasks = Enumerable.Range(0, concurrentRequests)
-            .Select(_ => service.MakeAuthenticatedRequest("GET", "/v1/test"))
+            .Select(_ => service.MakeAuthenticatedRequest("POST", "/v1/test", "{}"))
             .ToArray();
 
         await Task.WhenAll(tasks);
 
-        Assert.Equal(concurrentRequests, handler.Requests.Length);
-
         var nonces = handler.Requests
-            .Select(r => r.Headers.GetValues("x-bb-api-nonce").Single())
+            .Select(r => long.Parse(r.Headers.GetValues("x-bb-api-nonce").Single()))
             .ToArray();
 
         Assert.Equal(concurrentRequests, nonces.Distinct().Count());
+        Assert.All(nonces, nonce => Assert.True(nonce >= 1_000_000_000_000));
+        Assert.True(nonces.SequenceEqual(nonces.OrderBy(n => n)));
     }
 
     private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder = responder;
         public HttpRequestMessage[] Requests => _requests.ToArray();
-        private readonly System.Collections.Concurrent.ConcurrentBag<HttpRequestMessage> _requests = [];
+        private readonly ConcurrentQueue<HttpRequestMessage> _requests = [];
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            _requests.Add(request);
+            _requests.Enqueue(request);
             return Task.FromResult(_responder(request));
+        }
+    }
+
+    private sealed class AsyncRecordingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder = responder;
+        public HttpRequestMessage[] Requests => _requests.ToArray();
+        private readonly ConcurrentQueue<HttpRequestMessage> _requests = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _requests.Enqueue(request);
+            return await _responder(request);
         }
     }
 }

--- a/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Tests/BareBitcoinLightningClientTests.cs
@@ -127,6 +127,37 @@ public class BareBitcoinLightningClientTests
     }
 
     [Fact]
+    public async Task GetInvoice_UsesApiKeyOnlyAuthHeaders()
+    {
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new RecordingMessageHandler(ApiJson("INVOICE_STATUS_UNPAID"));
+        var client = CreateClient(handler, invoiceService);
+
+        await client.GetInvoice("inv-auth");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.True(request.Headers.Contains("x-bb-api-key"));
+        Assert.False(request.Headers.Contains("x-bb-api-nonce"));
+        Assert.False(request.Headers.Contains("x-bb-api-hmac"));
+    }
+
+    [Fact]
+    public async Task CreateInvoice_UsesFullHmacAuthHeaders()
+    {
+        var invoiceService = new ThrowingInvoiceService();
+        var handler = new RecordingMessageHandler(CreateInvoiceApiJson());
+        var client = CreateClient(handler, invoiceService);
+
+        await client.CreateInvoice(
+            new CreateInvoiceParams(LightMoney.Satoshis(1000), "test", TimeSpan.FromHours(1)));
+
+        var request = Assert.Single(handler.Requests);
+        Assert.True(request.Headers.Contains("x-bb-api-key"));
+        Assert.True(request.Headers.Contains("x-bb-api-nonce"));
+        Assert.True(request.Headers.Contains("x-bb-api-hmac"));
+    }
+
+    [Fact]
     public async Task CreateInvoice_PropagatesOperationCanceledException_FromTrackInvoice()
     {
         var invoiceService = new ThrowingInvoiceService(
@@ -423,6 +454,22 @@ public class BareBitcoinLightningClientTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class RecordingMessageHandler(string responseBody) : HttpMessageHandler
+    {
+        private readonly ConcurrentQueue<HttpRequestMessage> _requests = new();
+        public HttpRequestMessage[] Requests => _requests.ToArray();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _requests.Enqueue(request);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(responseBody, Encoding.UTF8, "application/json")

--- a/barebitcoin-lightning-connection-setup.js
+++ b/barebitcoin-lightning-connection-setup.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 "use strict";
 
-const crypto = require("crypto");
 const readline = require("readline");
 const https = require("https");
 
@@ -38,35 +37,6 @@ async function main() {
   // Set up request components
   const method = "GET";
   const path = "/v1/user/bitcoin-accounts";
-  const nonce = Math.floor(Date.now() / 1000).toString();
-
-  // Create nonce hash (binary output)
-  const nonceHash = crypto
-    .createHash("sha256")
-    .update(nonce, "utf8")
-    .digest();
-
-  // Concatenate method, path, and nonceHash
-  const messageBuffer = Buffer.concat([
-    Buffer.from(method + path, "utf8"),
-    nonceHash,
-  ]);
-
-  // Decode secret key (base64-decoded)
-  let secretDecoded;
-  try {
-    secretDecoded = Buffer.from(secretKey, "base64");
-  } catch (err) {
-    console.error("Error: Failed to decode secret key from base64.");
-    process.exit(1);
-  }
-
-  // Create HMAC (binary output, then base64-encode it)
-  const hmacBuffer = crypto
-    .createHmac("sha256", secretDecoded)
-    .update(messageBuffer)
-    .digest();
-  const hmac = hmacBuffer.toString("base64");
 
   // Set up API request options
   const options = {
@@ -75,9 +45,7 @@ async function main() {
     path: path,
     method: method,
     headers: {
-      "x-bb-api-hmac": hmac,
       "x-bb-api-key": publicKey,
-      "x-bb-api-nonce": nonce,
     },
   };
 

--- a/plugin/BareBitcoinLightningClient.cs
+++ b/plugin/BareBitcoinLightningClient.cs
@@ -144,7 +144,7 @@ public class BareBitcoinLightningClient : ILightningClient
         string response;
         try
         {
-            response = await _apiService.MakeAuthenticatedRequest("GET", $"/v1/deposit-destinations/bitcoin/invoice/{invoiceId}");
+            response = await _apiService.MakeAuthenticatedRequest("GET", $"/v1/deposit-destinations/bitcoin/invoice/{invoiceId}", useSimpleAuth: true);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {

--- a/plugin/Services/BareBitcoinApiService.cs
+++ b/plugin/Services/BareBitcoinApiService.cs
@@ -22,8 +22,9 @@ public class BareBitcoinApiService
     private readonly ILogger _logger;
     private readonly string _tracePrefix;
 
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _requestLocks = new();
-    private static readonly ConcurrentDictionary<string, long> _lastNonceByPublicKey = new();
+    private const int MaxAuthStatesBeforeCleanup = 1024;
+    private static readonly TimeSpan AuthStateIdleLifetime = TimeSpan.FromHours(1);
+    private static readonly ConcurrentDictionary<string, AuthState> _authStates = new();
 
     /// <summary>
     /// Initializes a new instance of the BareBitcoinApiService.
@@ -47,13 +48,11 @@ public class BareBitcoinApiService
     /// The nonce is guaranteed to be monotonically increasing for the public API key.
     /// </summary>
     /// <returns>The next nonce value to use</returns>
-    private long GetNextNonce()
+    private long GetNextNonce(AuthState authState)
     {
         var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        return _lastNonceByPublicKey.AddOrUpdate(
-            _publicKey,
-            currentTimestamp,
-            (_, lastNonce) => Math.Max(lastNonce + 1, currentTimestamp));
+        authState.LastNonce = Math.Max(authState.LastNonce + 1, currentTimestamp);
+        return authState.LastNonce;
     }
 
     /// <summary>
@@ -128,11 +127,14 @@ public class BareBitcoinApiService
             return await MakeRequest(method, path, data);
         }
         
-        var requestLock = _requestLocks.GetOrAdd(_publicKey, _ => new SemaphoreSlim(1, 1));
-        await requestLock.WaitAsync();
+        var authState = RetainAuthState();
+        var requestLockAcquired = false;
         try
         {
-            var nonce = GetNextNonce();
+            await authState.RequestLock.WaitAsync();
+            requestLockAcquired = true;
+
+            var nonce = GetNextNonce(authState);
             var hmac = CreateHmac(_privateKey, method, path, nonce, data);
 
             var additionalHeaders = new Dictionary<string, string>
@@ -146,8 +148,81 @@ public class BareBitcoinApiService
         }
         finally
         {
-            requestLock.Release();
+            if (requestLockAcquired)
+            {
+                authState.RequestLock.Release();
+            }
+
+            ReleaseAuthState(authState);
         }
+    }
+
+    private AuthState RetainAuthState()
+    {
+        while (true)
+        {
+            var authState = _authStates.GetOrAdd(_publicKey, _ => new AuthState());
+            lock (authState.Sync)
+            {
+                if (authState.Removed)
+                {
+                    continue;
+                }
+
+                authState.ReferenceCount++;
+                authState.LastUsed = DateTimeOffset.UtcNow;
+                return authState;
+            }
+        }
+    }
+
+    private void ReleaseAuthState(AuthState authState)
+    {
+        lock (authState.Sync)
+        {
+            authState.ReferenceCount--;
+            authState.LastUsed = DateTimeOffset.UtcNow;
+        }
+
+        PruneIdleAuthStates();
+    }
+
+    private static void PruneIdleAuthStates()
+    {
+        if (_authStates.Count <= MaxAuthStatesBeforeCleanup)
+        {
+            return;
+        }
+
+        var pruneBefore = DateTimeOffset.UtcNow - AuthStateIdleLifetime;
+        foreach (var entry in _authStates)
+        {
+            var authState = entry.Value;
+            lock (authState.Sync)
+            {
+                if (authState.ReferenceCount != 0 ||
+                    authState.Removed ||
+                    authState.LastUsed >= pruneBefore ||
+                    authState.RequestLock.CurrentCount == 0)
+                {
+                    continue;
+                }
+
+                authState.Removed = true;
+            }
+
+            _authStates.TryRemove(entry.Key, out _);
+        }
+    }
+
+    private sealed class AuthState
+    {
+        public object Sync { get; } = new();
+        public SemaphoreSlim RequestLock { get; } = new(1, 1);
+        public int ReferenceCount { get; set; }
+        public long LastNonce { get; set; }
+        public DateTimeOffset LastUsed { get; set; } = DateTimeOffset.UtcNow;
+        public bool Removed { get; set; }
     }
 
     /// <summary>

--- a/plugin/Services/BareBitcoinApiService.cs
+++ b/plugin/Services/BareBitcoinApiService.cs
@@ -25,6 +25,7 @@ public class BareBitcoinApiService
     private const int MaxAuthStatesBeforeCleanup = 1024;
     private static readonly TimeSpan AuthStateIdleLifetime = TimeSpan.FromHours(1);
     private static readonly ConcurrentDictionary<string, AuthState> _authStates = new();
+    private static int _isPruningAuthStates;
 
     /// <summary>
     /// Initializes a new instance of the BareBitcoinApiService.
@@ -194,24 +195,39 @@ public class BareBitcoinApiService
             return;
         }
 
-        var pruneBefore = DateTimeOffset.UtcNow - AuthStateIdleLifetime;
-        foreach (var entry in _authStates)
+        if (Interlocked.CompareExchange(ref _isPruningAuthStates, 1, 0) != 0)
         {
-            var authState = entry.Value;
-            lock (authState.Sync)
+            return;
+        }
+
+        try
+        {
+            var pruneBefore = DateTimeOffset.UtcNow - AuthStateIdleLifetime;
+            foreach (var entry in _authStates)
             {
-                if (authState.ReferenceCount != 0 ||
-                    authState.Removed ||
-                    authState.LastUsed >= pruneBefore ||
-                    authState.RequestLock.CurrentCount == 0)
+                var authState = entry.Value;
+                lock (authState.Sync)
                 {
-                    continue;
+                    if (authState.ReferenceCount != 0 ||
+                        authState.Removed ||
+                        authState.LastUsed >= pruneBefore ||
+                        authState.RequestLock.CurrentCount == 0)
+                    {
+                        continue;
+                    }
+
+                    authState.Removed = true;
                 }
 
-                authState.Removed = true;
+                if (_authStates.TryRemove(entry.Key, out _))
+                {
+                    authState.RequestLock.Dispose();
+                }
             }
-
-            _authStates.TryRemove(entry.Key, out _);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _isPruningAuthStates, 0);
         }
     }
 

--- a/plugin/Services/BareBitcoinApiService.cs
+++ b/plugin/Services/BareBitcoinApiService.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -21,9 +22,8 @@ public class BareBitcoinApiService
     private readonly ILogger _logger;
     private readonly string _tracePrefix;
 
-    // Static nonce tracking with async-compatible lock
-    private static readonly SemaphoreSlim _nonceLock = new SemaphoreSlim(1, 1);
-    private static long _lastNonce;
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _requestLocks = new();
+    private static readonly ConcurrentDictionary<string, long> _lastNonceByPublicKey = new();
 
     /// <summary>
     /// Initializes a new instance of the BareBitcoinApiService.
@@ -44,22 +44,16 @@ public class BareBitcoinApiService
 
     /// <summary>
     /// Gets the next nonce value for HMAC authentication in a thread-safe manner.
-    /// The nonce is guaranteed to be monotonically increasing and greater than the current timestamp.
+    /// The nonce is guaranteed to be monotonically increasing for the public API key.
     /// </summary>
     /// <returns>The next nonce value to use</returns>
-    private async Task<long> GetNextNonce()
+    private long GetNextNonce()
     {
-        await _nonceLock.WaitAsync();
-        try
-        {
-            var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            _lastNonce = Math.Max(_lastNonce + 1, currentTimestamp);
-            return _lastNonce;
-        }
-        finally
-        {
-            _nonceLock.Release();
-        }
+        var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        return _lastNonceByPublicKey.AddOrUpdate(
+            _publicKey,
+            currentTimestamp,
+            (_, lastNonce) => Math.Max(lastNonce + 1, currentTimestamp));
     }
 
     /// <summary>
@@ -76,7 +70,6 @@ public class BareBitcoinApiService
     {
         try 
         {
-            // Convert millisecond nonce to string
             var nonceStr = nonce.ToString();
             // Encode data: nonce and raw data
             var encodedData = data != null ? $"{nonceStr}{data}" : nonceStr;
@@ -135,20 +128,26 @@ public class BareBitcoinApiService
             return await MakeRequest(method, path, data);
         }
         
-        // Nonce generation is serialized via _nonceLock to guarantee uniqueness.
-        // Requests may arrive at the server out of nonce order under concurrency;
-        // the BareBitcoin API validates nonce uniqueness, not arrival order.
-        var nonce = await GetNextNonce();
-        var hmac = CreateHmac(_privateKey, method, path, nonce, data);
-
-        var additionalHeaders = new Dictionary<string, string>
+        var requestLock = _requestLocks.GetOrAdd(_publicKey, _ => new SemaphoreSlim(1, 1));
+        await requestLock.WaitAsync();
+        try
         {
-            ["x-bb-api-hmac"] = hmac,
-            ["x-bb-api-nonce"] = nonce.ToString()
-        };
+            var nonce = GetNextNonce();
+            var hmac = CreateHmac(_privateKey, method, path, nonce, data);
 
-        _logger.LogInformation("Making {method} request to {path} with nonce {nonce}", method, path, nonce);
-        return await MakeRequest(method, path, data, additionalHeaders);
+            var additionalHeaders = new Dictionary<string, string>
+            {
+                ["x-bb-api-hmac"] = hmac,
+                ["x-bb-api-nonce"] = nonce.ToString()
+            };
+
+            _logger.LogInformation("Making {method} request to {path} with nonce {nonce}", method, path, nonce);
+            return await MakeRequest(method, path, data, additionalHeaders);
+        }
+        finally
+        {
+            requestLock.Release();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Use API-key-only auth for BareBitcoin invoice polling GET requests
- Keep full HMAC auth for invoice creation POSTs
- Serialize signed requests per public API key and generate millisecond-scale increasing nonces
- Update setup script account lookup to use API-key-only GET auth

## Tests
- dotnet test BTCPayServer.Plugins.Tests/BTCPayServer.Plugins.Tests.csproj

Note: repo-root `dotnet test` does not apply because the root directory has no solution/project file.